### PR TITLE
Use custom autocomplete instead of browser's datalist

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -1,0 +1,96 @@
+export { Autocomplete };
+
+class Autocomplete {
+    #element_id;
+    #search_form_id;
+    #try_add_player_name;
+    #index;
+
+    constructor(element_id, search_form_id, add_player_cb) {
+        this.#element_id = element_id;
+        this.#search_form_id = search_form_id;
+        this.#try_add_player_name = add_player_cb;
+        this.#index = -1;
+
+        this.init();
+    }
+
+    init() {
+        let result = document.getElementById(this.#element_id);
+        result.classList.add('hidden');
+    }
+
+    populate(results) {
+        let element = document.getElementById(this.#element_id);
+        let list = document.createElement('ul');
+        for (const result of results) {
+            let entry = document.createElement('li');
+            entry.innerText = result;
+            list.appendChild(entry);
+        }
+
+        element.replaceChildren(list);
+        element.classList.remove('hidden');
+        this.#index = -1;
+    }
+
+    keyevents(ev) {
+        let search_form = document.getElementById(this.#search_form_id);
+        let result = document.getElementById(this.#element_id);
+        // Sanity check there is a list and if not, reset to nothing.
+        const list = result.firstChild;
+        if (!list) {
+            this.#index = -1;
+            return;
+        }
+
+        if (ev.code === "ArrowUp" || ev.code === "ArrowDown") {
+            ev.preventDefault();
+
+            let offset = 0;
+            if (ev.code === "ArrowUp") {
+                offset = -1;
+            }
+            else {
+                offset = 1;
+            }
+            this.#index = Math.max(0, Math.min(this.#index + offset, list.childNodes.length - 1));
+
+            for (let i = 0; i < list.childNodes.length; i++) {
+                let entry = list.childNodes[i];
+                if (i === this.#index) {
+                    entry.classList.add("hovered");
+                    entry.scrollIntoView({block: "nearest", inline: "nearest"});
+                }
+                else {
+                    entry.classList.remove("hovered");
+                }
+            }
+        }
+        else if (ev.code === "Enter") {
+            if (this.#index >= 0 && this.#index < (list.childNodes.length - 1)) {
+                let entry = list.childNodes[this.#index];
+                const player_name = entry.innerText;
+                if (this.#try_add_player_name(player_name)) {
+                    search_form.value = "";
+                    this.hide();
+                }
+            }
+        }
+    }
+
+    click(ev) {
+        const player_name = ev.target.innerText;
+        if (this.#try_add_player_name(player_name)) {
+            let search_form = document.getElementById(this.#search_form_id);
+            search_form.value = "";
+            this.hide();
+        }
+    }
+
+    hide() {
+        let result = document.getElementById(this.#element_id);
+        result.classList.add('hidden');
+        this.#index = -1;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,31 @@
                 flex: 1 18em;
             }
 
+            #autocomplete-results {
+                border: 1px solid #ccc;
+                padding: 3px;
+                max-height: 10em;
+                overflow: scroll;
+            }
+
+            #autocomplete-results ul {
+                list-style-type: none;
+                padding: 0;
+                margin: 0;
+            }
+
+            #autocomplete-results ul li {
+                padding: 5px 0;
+            }
+
+            #autocomplete-results ul li:hover {
+                background: #eee;
+            }
+
+            #autocomplete-results ul li.hovered {
+                background: #ccc;
+            }
+
             .description {
                 flex: 9 50em;
             }
@@ -31,16 +56,14 @@
         <h1>Better than Other Ordinary Guys Graphs</h1>
         <div class="settings">
             <div id="add-players">
-                <div id="show-datalist">
-                    <label for="player-choice">Add players:</label>
-                    <input autocomplete="off" type="search" list="player-list" id="player-choice" name="player-choice" />
-                </div>
-                <div id="show-select" class="hidden">
-                    <select id="player-select"></select>
-                </div>
+                <label for="player-choice">Add players:</label>
+                <form autocomplete="off">
+                    <button type="submit" disabled class="hidden" aria-hidden="true"></button>
+                    <input type="search" id="player-choice" name="player-choice" />
+                    <div id="autocomplete-results" data-item="-1" class="hidden"></div>
+                </form>
                 <ul id="chosen-players"></ul>
                 <button id="create" type="button">Create BOOG Graph</button>
-                <datalist id="player-list"></datalist>
             </div>
             <div class="description">
                 <h3>What is BOOG?</h3>
@@ -87,12 +110,6 @@
             <div id="bbwaa"></div>
             <canvas class="hidden" id="bbwaa-canvas"></canvas>
             <a id="bbwaa-image" class="hidden" href="#">View image</a>
-        </div>
-        <div>
-            <hr>
-            <h4>Options</h4>
-            <label for="option-use-select">Use select rather than datalist</label>
-            <input type="checkbox" id="option-use-select">
         </div>
         <script src="d3.v7.min.js"></script>
         <script async src="graph.js" type="module"></script>

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
                 <form autocomplete="off">
                     <button type="submit" disabled class="hidden" aria-hidden="true"></button>
                     <input type="search" id="player-choice" name="player-choice" />
-                    <div id="autocomplete-results" data-item="-1" class="hidden"></div>
+                    <div id="autocomplete-results" class="hidden"></div>
                 </form>
                 <ul id="chosen-players"></ul>
                 <button id="create" type="button">Create BOOG Graph</button>


### PR DESCRIPTION
Replace the datalist method that had zero support in Firefox for Android and awkward support on mobile with something completely custom.