### PR TITLE
Increase margin around buttons for mobile screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
         <title>Better than Other Ordinary Guys Graphs</title>
         <meta charset="utf-8">
         <style>
+            button {
+                margin: 6px;
+            }
+
             .settings {
                 display: flex;
                 justify-content: space-between;


### PR DESCRIPTION
I added 6px margin around the buttons. That seemed to be enough on Firefox for Android and Chrome Mobile.